### PR TITLE
Moves the onclick handlers to the actual buttons

### DIFF
--- a/src/components/InfoModal.js
+++ b/src/components/InfoModal.js
@@ -17,12 +17,11 @@ export default class InfoModal extends PureComponent {
 
   render() {
     return (
-      <button className="p-1 rounded-full bg-transparent text-black hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white focus:outline-none">
-        <InformationCircleIcon
-          className="h-6 w-6"
-          aria-hidden="true"
-          onClick={this.setIsOpen(true)}
-        />
+      <button
+        className="p-1 rounded-full bg-transparent text-black hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white focus:outline-none"
+        onClick={this.setIsOpen(true)}
+      >
+        <InformationCircleIcon className="h-6 w-6" aria-hidden="true" />
 
         <Transition appear show={this.state.isOpen} as={Fragment}>
           <Dialog

--- a/src/components/ScrollableCarousel.js
+++ b/src/components/ScrollableCarousel.js
@@ -127,16 +127,18 @@ export default class ScrollableCarousel extends PureComponent {
             this.state.fullyLeftScrolled
               ? "opacity-0 pointer-events-none"
               : "opacity-100",
-            "absolute cursor-pointer select-none -left-2 top-1/2 transform -translate-y-1/2 z-10 transition-all duration-250"
+            "absolute select-none -left-2 top-1/2 transform -translate-y-1/2 z-10 transition-all duration-250"
           )}
         >
-          <div className="sticky bg-gray-900 text-white dark:bg-white dark:text-black rounded-full p-2 shadow-2xl transform scale-95 hover:scale-100 opacity-40 sm:opacity-80 hover:opacity-100 transition-opacity transition-transform duration-250">
+          <div
+            className="cursor-pointer sticky bg-gray-900 text-white dark:bg-white dark:text-black rounded-full p-2 shadow-2xl transform scale-95 hover:scale-100 opacity-40 sm:opacity-80 hover:opacity-100 transition-opacity transition-transform duration-250"
+            onClick={this.scrollLeft}
+          >
             <ArrowLeftIcon
               className={`rounded-full z-10 p-0 w-${
                 this.props.iconSize ? this.props.iconSize : 8
               } h-${this.props.iconSize ? this.props.iconSize : 8}`}
               aria-hidden="true"
-              onClick={this.scrollLeft}
             />
           </div>
         </div>
@@ -160,16 +162,18 @@ export default class ScrollableCarousel extends PureComponent {
             this.state.fullyRightScrolled
               ? "opacity-0 pointer-events-none"
               : "opacity-100",
-            "absolute cursor-pointer select-none -right-2 top-1/2 transform -translate-y-1/2 z-10 transition-all duration-250"
+            "absolute select-none -right-2 top-1/2 transform -translate-y-1/2 z-10 transition-all duration-250"
           )}
         >
-          <div className="bg-gray-900 text-white dark:bg-white dark:text-black rounded-full p-2 shadow-2xl transform scale-95 hover:scale-100 opacity-40 sm:opacity-80 hover:opacity-100 transition-opacity transition-transform duration-250">
+          <div
+            className="cursor-pointer  bg-gray-900 text-white dark:bg-white dark:text-black rounded-full p-2 shadow-2xl transform scale-95 hover:scale-100 opacity-40 sm:opacity-80 hover:opacity-100 transition-opacity transition-transform duration-250"
+            onClick={this.scrollRight}
+          >
             <ArrowRightIcon
               className={`rounded-full z-10 p-0 w-${
                 this.props.iconSize ? this.props.iconSize : 8
               } h-${this.props.iconSize ? this.props.iconSize : 8}`}
               aria-hidden="true"
-              onClick={this.scrollRight}
             />
           </div>
         </div>

--- a/src/components/ThemeSwitcher.js
+++ b/src/components/ThemeSwitcher.js
@@ -39,11 +39,20 @@ export default class ThemeSwitcher extends PureComponent {
 
   render() {
     return (
-      <button className="p-1 rounded-full bg-transparent focus:outline-none text-black hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white mr-4">
+      <button
+        className="p-1 rounded-full bg-transparent focus:outline-none text-black hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white mr-4"
+        onClick={() => {
+          if (this.state.theme === "dark") {
+            this.setTheme("light");
+          } else {
+            this.setTheme("dark");
+          }
+        }}
+      >
         {this.state.theme === "dark" ? (
-          <SunIcon className="h-6 w-6" onClick={() => this.setTheme("light")} />
+          <SunIcon className="h-6 w-6" />
         ) : (
-          <MoonIcon className="h-6 w-6" onClick={() => this.setTheme("dark")} />
+          <MoonIcon className="h-6 w-6" />
         )}
       </button>
     );


### PR DESCRIPTION
Changes the carousel arrow buttons, theme button, and info button such that the onclick handler is on the button, not the icon inside of it.

Previously, the onclick handlers were on the icons, which could occasionally "seem" unresponsive if your cursor was on the button but not the icon (the button would highlight but clicking wouldn't actually do anything).

Previous behaviour in the header:
![proxy-buttons-old](https://user-images.githubusercontent.com/25498386/120943089-d30e8580-c6fa-11eb-94eb-c485362e7998.gif)


New behaviour:
![proxy-buttons-new](https://user-images.githubusercontent.com/25498386/120943093-d4d84900-c6fa-11eb-8729-617fd78db18b.gif)


