### PR TITLE
Fix carousel reactiveness

### DIFF
--- a/src/components/ScrollableCarousel.js
+++ b/src/components/ScrollableCarousel.js
@@ -112,6 +112,11 @@ export default class ScrollableCarousel extends PureComponent {
 
   componentDidMount = () => {
     this.observer.observe(this.componentRef.current);
+    window.addEventListener("resize", this.scrollPositionHandler);
+  };
+
+  componentWillUnmount = () => {
+    window.removeEventListener("resize", this.scrollPositionHandler);
   };
 
   render() {

--- a/src/containers/Discover.js
+++ b/src/containers/Discover.js
@@ -70,6 +70,7 @@ export default class Discover extends PureComponent {
         );
       }
     });
+
     return (
       <Container>
         {this.props.discover.size ? (
@@ -82,14 +83,14 @@ export default class Discover extends PureComponent {
                 onChange={this.setCurrentSource}
               >
                 {this.getSourceNamesAndIcons().map((source) => (
-                  <RadioGroup.Option as={Fragment} value={source.name}>
+                  <RadioGroup.Option
+                    as={Fragment}
+                    value={source.name}
+                    key={source.name}
+                  >
                     {({ checked }) => (
                       <button
                         disabled={source.disabled}
-                        key={
-                          source.name +
-                          (source.disabled ? "-disabled" : "-enabled")
-                        }
                         className={classNames(
                           checked
                             ? "bg-black text-white dark:bg-gray-800 dark:text-white"


### PR DESCRIPTION
Fixes an issue where resizing a window would not retrigger the carousal button detection render by just slapping on an event listener.

Also fixed an annoying duplicate-key warning.

Old behaviour:
![proxy-old-carousel](https://user-images.githubusercontent.com/25498386/120946310-03a9eb80-c70a-11eb-82d1-bc82233ab465.gif)

Updated behaviour:
![proxy-new-carousel](https://user-images.githubusercontent.com/25498386/120946335-17555200-c70a-11eb-84aa-9550c2e58481.gif)

