### PR TITLE
Fixes a warning screaming about how you can't nest a section in a p

### DIFF
--- a/src/components/InfoModal.js
+++ b/src/components/InfoModal.js
@@ -49,22 +49,26 @@ export default class InfoModal extends PureComponent {
                 leaveTo="opacity-0 scale-95"
               >
                 <div className="text-black dark:text-white inline-block bg-gray-100 dark:bg-gray-800 w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-lg">
-                  <Dialog.Description className="-mt-2">
-                    <Section text="About"></Section>
-                    While this project is related to cubari.moe, it should be
-                    considered distinct (and will evolve independently of the main
-                    website).
-                    <br></br>
-                    <br></br>
-                    Sources that have decent readers and/or no ads may be
-                    included.
-                    <Section text="Credits"></Section>
-                    All sources are powered by Paperback's extensions.{" "}
-                    <a href="https://paperback.moe/">
-                      Check out the app if you're on iOS.
-                    </a>
-                  </Dialog.Description>
-
+                  {/* Ugly wrapper thing for now I guess? */}
+                  <div className="-mt-2">
+                    <Section text="About" />
+                    <Dialog.Description>
+                      While this project is related to cubari.moe, it should be
+                      considered distinct (and will evolve independently of the
+                      main website).
+                      <br></br>
+                      <br></br>
+                      Sources that have decent readers and/or no ads may be
+                      included.
+                    </Dialog.Description>
+                    <Section text="Credits" />
+                    <Dialog.Description>
+                      All sources are powered by Paperback's extensions.{" "}
+                      <a href="https://paperback.moe/">
+                        Check out the app if you're on iOS.
+                      </a>
+                    </Dialog.Description>
+                  </div>
                   <button
                     className="mt-10 bg-transparent text-black hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium"
                     onClick={this.setIsOpen(false)}


### PR DESCRIPTION
Fixes a warning that would be given when opening the info screen:


```
Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
    in div (at Section.js:8)
    in section (at Section.js:7)
    in Section (at InfoModal.js:61)
    in p (created by Description)
    in Description (at InfoModal.js:52)
    in div (at InfoModal.js:51)
    in OpenClosedProvider (created by TransitionChild)
    in TransitionChild (at InfoModal.js:42)
    in div (at InfoModal.js:34)
    in div (created by Dialog)
    in DescriptionProvider (created by Dialog)
    in ForcePortalRoot (created by Dialog)
    in Group (created by Dialog)
    in Portal (created by Dialog)
    in ForcePortalRoot (created by Dialog)
    in StackProvider (created by Dialog)
    in Dialog (at InfoModal.js:28)
    in OpenClosedProvider (created by TransitionChild)
    in TransitionChild (created by Transition)
    in Transition (at InfoModal.js:27)
    in button (at InfoModal.js:20)
    in InfoModal (at App.js:133)
    in div (at App.js:130)
    in div (at App.js:67)
    in div (at App.js:66)
    in nav (created by Menu)
    in OpenClosedProvider (created by Menu)
    in Menu (at App.js:65)
    in Router (created by HashRouter)
    in HashRouter (at App.js:64)
    in App (at src/index.js:8)
    in StrictMode (at src/index.js:7)
```

Just needed to shuffle some elements around and it's fine.  It looks the same too.

Before:
![image](https://user-images.githubusercontent.com/25498386/120947356-5cc74e80-c70d-11eb-8e26-c19144de45ef.png)

After:
![image](https://user-images.githubusercontent.com/25498386/120947333-4e793280-c70d-11eb-8b57-59ee9b7efff0.png)

