### PR TITLE
Fix bug where carousel buttons would break after hitting bounds

### DIFF
--- a/src/components/ScrollableCarousel.js
+++ b/src/components/ScrollableCarousel.js
@@ -133,9 +133,7 @@ export default class ScrollableCarousel extends PureComponent {
   render() {
     const { fullyLeftScrolled, fullyRightScrolled, isButtonHovered } =
       this.state;
-
-    const { iconSize } = this.props;
-    const calculatedIconSize = iconSize || 8;
+    const { iconSize = 8 } = this.props;
 
     return (
       <div className="relative w-full h-full" ref={this.componentRef}>
@@ -153,7 +151,7 @@ export default class ScrollableCarousel extends PureComponent {
             onMouseLeave={this.onMouseLeave}
           >
             <ArrowLeftIcon
-              className={`rounded-full z-10 p-0 w-${calculatedIconSize} h-${calculatedIconSize}`}
+              className={`rounded-full z-10 p-0 w-${iconSize} h-${iconSize}`}
               aria-hidden="true"
             />
           </div>
@@ -187,7 +185,7 @@ export default class ScrollableCarousel extends PureComponent {
             onMouseLeave={this.onMouseLeave}
           >
             <ArrowRightIcon
-              className={`rounded-full z-10 p-0 w-${calculatedIconSize} h-${calculatedIconSize}`}
+              className={`rounded-full z-10 p-0 w-${iconSize} h-${iconSize}`}
               aria-hidden="true"
             />
           </div>

--- a/src/components/ScrollableCarousel.js
+++ b/src/components/ScrollableCarousel.js
@@ -11,9 +11,8 @@ export default class ScrollableCarousel extends PureComponent {
     super(props);
     this.state = {
       fullyLeftScrolled: true,
-      fullyRemoveLeftButton: false,
       fullyRightScrolled: true,
-      fullyRemoveRightButton: false,
+      mouseHoveringButton: false,
       scrolling: false,
       itemLength: 0,
     };
@@ -121,29 +120,41 @@ export default class ScrollableCarousel extends PureComponent {
     window.removeEventListener("resize", this.scrollPositionHandler);
   };
 
+  onMouseEnter = () =>
+    this.setState({
+      mouseHoveringButton: true,
+    });
+
+  onMouseLeave = () =>
+    this.setState({
+      mouseHoveringButton: false,
+    });
+
   render() {
+    const { fullyLeftScrolled, fullyRightScrolled, mouseHoveringButton } =
+      this.state;
+
+    const { iconSize } = this.props;
+
     return (
       <div className="relative w-full h-full" ref={this.componentRef}>
         <div
+          hidden={fullyLeftScrolled && !mouseHoveringButton}
           className={classNames(
-            this.state.fullyLeftScrolled ? "opacity-0" : "opacity-100",
-            this.state.fullyRemoveLeftButton ? "pointer-events-none" : "",
+            fullyLeftScrolled ? "opacity-0" : "opacity-100",
             "absolute select-none -left-2 top-1/2 transform -translate-y-1/2 z-10 transition-all duration-250"
           )}
-          onMouseLeave={() =>
-            this.setState({
-              fullyRemoveLeftButton: this.state.fullyLeftScrolled,
-            })
-          }
         >
           <div
             className="cursor-pointer sticky bg-gray-900 text-white dark:bg-white dark:text-black rounded-full p-2 shadow-2xl transform scale-95 hover:scale-100 opacity-40 sm:opacity-80 hover:opacity-100 transition-opacity transition-transform duration-250"
             onClick={this.scrollLeft}
+            onMouseEnter={this.onMouseEnter}
+            onMouseLeave={this.onMouseLeave}
           >
             <ArrowLeftIcon
               className={`rounded-full z-10 p-0 w-${
-                this.props.iconSize ? this.props.iconSize : 8
-              } h-${this.props.iconSize ? this.props.iconSize : 8}`}
+                iconSize ? iconSize : 8
+              } h-${iconSize ? iconSize : 8}`}
               aria-hidden="true"
             />
           </div>
@@ -164,25 +175,22 @@ export default class ScrollableCarousel extends PureComponent {
           <Spinner />
         ) : undefined}
         <div
+          hidden={fullyRightScrolled && !mouseHoveringButton}
           className={classNames(
-            this.state.fullyRightScrolled ? "opacity-0" : "opacity-100",
-            this.state.fullyRemoveRightButton ? "pointer-events-none" : "",
+            fullyRightScrolled ? "opacity-0" : "opacity-100",
             "absolute select-none -right-2 top-1/2 transform -translate-y-1/2 z-10 transition-all duration-250"
           )}
-          onMouseLeave={() =>
-            this.setState({
-              fullyRemoveRightButton: this.state.fullyRightScrolled,
-            })
-          }
         >
           <div
             className="cursor-pointer  bg-gray-900 text-white dark:bg-white dark:text-black rounded-full p-2 shadow-2xl transform scale-95 hover:scale-100 opacity-40 sm:opacity-80 hover:opacity-100 transition-opacity transition-transform duration-250"
             onClick={this.scrollRight}
+            onMouseEnter={this.onMouseEnter}
+            onMouseLeave={this.onMouseLeave}
           >
             <ArrowRightIcon
               className={`rounded-full z-10 p-0 w-${
-                this.props.iconSize ? this.props.iconSize : 8
-              } h-${this.props.iconSize ? this.props.iconSize : 8}`}
+                iconSize ? iconSize : 8
+              } h-${iconSize ? iconSize : 8}`}
               aria-hidden="true"
             />
           </div>

--- a/src/components/ScrollableCarousel.js
+++ b/src/components/ScrollableCarousel.js
@@ -12,7 +12,7 @@ export default class ScrollableCarousel extends PureComponent {
     this.state = {
       fullyLeftScrolled: true,
       fullyRightScrolled: true,
-      mouseHoveringButton: false,
+      isButtonHovered: false,
       scrolling: false,
       itemLength: 0,
     };
@@ -122,24 +122,25 @@ export default class ScrollableCarousel extends PureComponent {
 
   onMouseEnter = () =>
     this.setState({
-      mouseHoveringButton: true,
+      isButtonHovered: true,
     });
 
   onMouseLeave = () =>
     this.setState({
-      mouseHoveringButton: false,
+      isButtonHovered: false,
     });
 
   render() {
-    const { fullyLeftScrolled, fullyRightScrolled, mouseHoveringButton } =
+    const { fullyLeftScrolled, fullyRightScrolled, isButtonHovered } =
       this.state;
 
     const { iconSize } = this.props;
+    const calculatedIconSize = iconSize || 8;
 
     return (
       <div className="relative w-full h-full" ref={this.componentRef}>
         <div
-          hidden={fullyLeftScrolled && !mouseHoveringButton}
+          hidden={fullyLeftScrolled && !isButtonHovered}
           className={classNames(
             fullyLeftScrolled ? "opacity-0" : "opacity-100",
             "absolute select-none -left-2 top-1/2 transform -translate-y-1/2 z-10 transition-all duration-250"
@@ -152,9 +153,7 @@ export default class ScrollableCarousel extends PureComponent {
             onMouseLeave={this.onMouseLeave}
           >
             <ArrowLeftIcon
-              className={`rounded-full z-10 p-0 w-${
-                iconSize ? iconSize : 8
-              } h-${iconSize ? iconSize : 8}`}
+              className={`rounded-full z-10 p-0 w-${calculatedIconSize} h-${calculatedIconSize}`}
               aria-hidden="true"
             />
           </div>
@@ -175,7 +174,7 @@ export default class ScrollableCarousel extends PureComponent {
           <Spinner />
         ) : undefined}
         <div
-          hidden={fullyRightScrolled && !mouseHoveringButton}
+          hidden={fullyRightScrolled && !isButtonHovered}
           className={classNames(
             fullyRightScrolled ? "opacity-0" : "opacity-100",
             "absolute select-none -right-2 top-1/2 transform -translate-y-1/2 z-10 transition-all duration-250"
@@ -188,9 +187,7 @@ export default class ScrollableCarousel extends PureComponent {
             onMouseLeave={this.onMouseLeave}
           >
             <ArrowRightIcon
-              className={`rounded-full z-10 p-0 w-${
-                iconSize ? iconSize : 8
-              } h-${iconSize ? iconSize : 8}`}
+              className={`rounded-full z-10 p-0 w-${calculatedIconSize} h-${calculatedIconSize}`}
               aria-hidden="true"
             />
           </div>


### PR DESCRIPTION
Fixes an issue where the carousel buttons would break after you hit the left/right bounds, since the state to re-enable them never occurred.  This change just modifies the hiding triggers a bit so re-enabling the buttons can occur.  It also has the side effect of properly hiding the buttons on mobile - previously, they would just stay there forever with 0 opacity since you could never trigger them being disabled.

This does break the use case of disabling the buttons while spam clicking on mobile though, since there is no `onMouseEnter` trigger... though I would believe mobile users are more likely to scroll.

IMO it might be better to just leave the buttons in a disabled state or move them outward a bit so they don't cover up the titles as opposed to this hack, but for now, this at least fixes the buttons from "jamming".

Old behaviour:
![proxy-carousel-bug-old](https://user-images.githubusercontent.com/25498386/122310952-1fb64580-cedf-11eb-91d6-94b5dadfef98.gif)


New behaviour:
![proxy-carousel-bug-new](https://user-images.githubusercontent.com/25498386/122310593-a7e81b00-cede-11eb-8cbd-8561af43e1bb.gif)

